### PR TITLE
Updated impresum

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -34,6 +34,7 @@
 		<a class="stretchy-footer-link" class:active={currentUrl.startsWith('/casopisi')} href="/casopisi">Časopisi</a>
 		<a class="stretchy-footer-link" class:active={currentUrl.startsWith('/natjecanja')} href="/natjecanja">Natjecanja</a>
 		<a class="stretchy-footer-link" class:active={currentUrl.startsWith('/o-nama')} href="/o-nama">O nama</a>
+		<a class="stretchy-footer-link" class:active={currentUrl.startsWith('/impresum')} href="/impresum">Impresum</a>
 	</nav>
 
 	<div class="md:ml-auto flex flex-wrap items-center justify-end gap-x-4 md:gap-x-6 gap-y-1 md:gap-1 w-max md:w-48 lg:w-max">

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -57,6 +57,10 @@
             <a class="navbar-link navbar-link-{theme}" class:active={currentUrl.startsWith('/o-nama')}
                href="/o-nama">O nama</a>
         </li>
+        <li>
+            <a class="navbar-link navbar-link-{theme}" class:active={currentUrl.startsWith('/impresum')}
+               href="/impresum">Impresum</a>
+        </li>
     </ul>
 
     <div class="flex gap-5">
@@ -111,6 +115,8 @@
                    class:active={currentUrl.startsWith('/natjecanja')} href="/natjecanja">Natjecanja</a></li>
             <li><a on:click={() => mobileMenuOpen = false} class="wide-title navbar-link navbar-link-{theme}"
                    class:active={currentUrl.startsWith('/o-nama')} href="/o-nama">O nama</a></li>
+            <li><a on:click={() => mobileMenuOpen = false} class="wide-title navbar-link navbar-link-{theme}"
+                   class:active={currentUrl.startsWith('/impresum')} href="/impresum">Impresum</a></li>
         </ul>
 
         <div class="flex flex-wrap gap-x-4 gap-y-1 md:gap-1 w-7/12 mt-auto">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,7 +15,8 @@
 		'/blog': 'blog',
 		'/casopisi': 'magazine',
 		'/natjecanja': 'competitive',
-		'/o-nama': 'about'
+		'/o-nama': 'about',
+		'/impresum': 'impresum'
 	}
 </script>
 
@@ -34,6 +35,7 @@
 	class:bg-blend-lighten={theme === 'competitive'}
 	class:dark:bg-blend-overlay={theme === 'competitive'}
 	class:theme-about={theme === 'about'}
+	class:theme-impresum={theme === 'impresum'}
 >
 	<Navbar {isLoggedIn} {theme} hasThemeToggle={!currentRoute.includes('/casopisi')} />
 
@@ -65,5 +67,9 @@
 
 	.theme-about {
 		@apply text-slate-900 dark:text-slate-50 bg-rose-200 dark:bg-black/90;
+	}
+
+	.theme-impresum {
+		@apply text-slate-900 dark:text-slate-50 bg-gray-100 dark:bg-black/90;
 	}
 </style>

--- a/src/routes/blog/putovanje-koje-nikad-ne-prestaje-part-3.md
+++ b/src/routes/blog/putovanje-koje-nikad-ne-prestaje-part-3.md
@@ -4,7 +4,7 @@ author: Ana Horvat
 date: 2023-10-02
 image: /clanci-slike/2023/putovanje-koje-nikad-ne-prestaje-part-3.jpg
 layout: blog
-featured: true
+featured: false
 categories:
   - 'kolumna'
 ---

--- a/src/routes/blog/student-hub-ispod-povrsine.md
+++ b/src/routes/blog/student-hub-ispod-povrsine.md
@@ -4,7 +4,8 @@ author: Anja Peharda
 date: 2024-04-06
 image: /clanci-slike/2024/student-hub-ispod-povrsine.png
 layout: blog
-featured: true
+featured: false
+sponsored: true
 categories:
   - 'kolumna'
 ---

--- a/src/routes/casopisi/+page.svelte
+++ b/src/routes/casopisi/+page.svelte
@@ -12,14 +12,18 @@
 </script>
 
 <svelte:head>
-    <title>Časopisi - St@k</title>
+    <title>Arhiva časopisa - St@k</title>
 </svelte:head>
 
-<h1 class="wide-title text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0">Časopisi</h1>
+<h1 class="wide-title text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0">Arhiva časopisa</h1>
 
 <div class="w-full flex max-xl:flex-col gap-40 p-10 md:p-20">
     <div class="w-80 md:w-auto md:max-w-2xl xl:w-80 shrink-0 xl:sticky xl:top-20 xl:self-start xl:ml-2 flex flex-col md:flex-row xl:flex-col max-xl:mx-auto gap-0 md:gap-8 xl:gap-0">
-        <img class="rounded-2xl shadow-2xl shadow-zinc-700 max-w-xs" src={latestMagazine.imgCover} alt="Naslovnica {latestMagazine.title}"/>
+        <div>
+            <a class="h-96 max-xl:items-center" href={latestMagazine.url}>
+                <img class="rounded-2xl shadow-2xl shadow-zinc-700 max-w-xs" src={latestMagazine.imgCover} alt="Naslovnica {latestMagazine.title}"/>
+            </a>
+        </div>
 
         <div class="mt-6 flex flex-col items-start">
             <h2 class="text-4xl font-headline font-bold tracking-tighter text-emerald-400">{@html latestMagazine.title}</h2>

--- a/src/routes/casopisi/[izdanje=integer]/+page.svelte
+++ b/src/routes/casopisi/[izdanje=integer]/+page.svelte
@@ -8,8 +8,7 @@
 
 <a style="font-stretch: 150%; font-weight: 280;" class="text-base flex items-center gap-2 mt-10 mb-6 mx-10 md:mx-20"
    href="/casopisi">
-    <ArrowLeft class="text-emerald-400 w-5 h-5"/>
-    Časopisi</a>
+    <ArrowLeft class="text-emerald-400 w-5 h-5"/>Arhiva časopisa</a>
 
 <h1 class="wide-title text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0">Stak {izdanje}</h1>
 

--- a/src/routes/impresum/+page.js
+++ b/src/routes/impresum/+page.js
@@ -1,0 +1,8 @@
+export async function load() {
+	const impresum = await import('./impresum.md')
+
+	return {
+		...impresum.metadata,
+		content: impresum.default
+	}
+}

--- a/src/routes/impresum/+page.svelte
+++ b/src/routes/impresum/+page.svelte
@@ -1,0 +1,20 @@
+<script>
+	export let data
+	const {content, date: rawDate} = data
+	const dateData = new Date(rawDate)
+	const date = new Intl.DateTimeFormat('hr-HR', {dateStyle: 'long'}).format(dateData)
+</script>
+
+<svelte:head>
+    <title>Impresum - St@k</title>
+</svelte:head>
+
+<h1 class="wide-title text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0">Impresum</h1>
+
+<section id="impresum" class="mt-20 md:m-20 mb-0 md:mb-0 p-10">
+    <div class="article-content mx-auto prose dark:prose-invert prose-headings:max-w-[56ch] prose-p:max-w-[56ch] text-prose text-justify text-zinc-900 dark:text-slate-50">
+        <svelte:component this={content}/>
+        <br>
+        <small>Ažurirano: {date}</small>
+    </div>
+</section>

--- a/src/routes/impresum/impresum.md
+++ b/src/routes/impresum/impresum.md
@@ -1,6 +1,6 @@
 ---
 title: Impresum
-date: 2024-05-04
+date: 2024-05-06
 ---
 
 <ins><strong>ST@K - ST</strong>udentska <strong>AK</strong>tivnost</ins>

--- a/src/routes/impresum/impresum.md
+++ b/src/routes/impresum/impresum.md
@@ -1,0 +1,84 @@
+---
+title: Impresum
+date: 2024-05-04
+---
+
+<ins><strong>ST@K - ST</strong>udentska <strong>AK</strong>tivnost</ins>
+
+Časopis studenata Fakulteta organizacije i informatike u Varaždinu izlazi dva puta godišnje u tiskanom i elektroničkom obliku.
+
+<table class="text-sm text-left rtl:text-right text-gray-500 dark:text-gray-400">
+    <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+        <tr>
+            <th scope="col" class="px-6 py-3">
+                Uloga
+            </th>
+            <th scope="col" class="px-6 py-3">
+                Članovi
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+            <th scope="row" class="px-6 py-4 font-medium text-gray-900 dark:text-white">
+                Glavni urednik
+            </th>
+            <td class="px-6 py-4">
+                Anja Peharda
+            </td>
+        </tr>
+        <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+            <th scope="row" class="px-6 py-4 font-medium text-gray-900 dark:text-white">
+                Zamjenik urednika
+            </th>
+            <td class="px-6 py-4">
+                Ana Horvat
+            </td>
+        </tr>
+        <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+            <th scope="row" class="px-6 py-4 font-medium text-gray-900 dark:text-white">
+                Lektura i korektura
+            </th>
+            <td class="px-6 py-4">
+                Antonija Munjeković, Anamarija Dominiković, Elena Kržina, Emilia Jelačić, Laura Krišković, Leonardo Petran, Anja Peharda
+            </td>
+        </tr>
+        <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+            <th scope="row" class="px-6 py-4 font-medium text-gray-900 dark:text-white">
+                Grafički dizajn
+            </th>
+            <td class="px-6 py-4">
+                David Slavik, Domagoj Babić, Marija Bekale, Kristijan Cepanec, Mateo Čuvalo, Leonarda Ferk, Petra Jakopović, Elena Kržina, Andreas Leja, Nina Obadić
+            </td>
+        </tr>
+        <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+            <th scope="row" class="px-6 py-4 font-medium text-gray-900 dark:text-white">
+                Web dizajn i programiranje
+            </th>
+            <td class="px-6 py-4">
+                Tin Tomašić
+            </td>
+        </tr>
+        <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+            <th scope="row" class="px-6 py-4 font-medium text-gray-900 dark:text-white">
+                Web administracija
+            </th>
+            <td class="px-6 py-4">
+                Tin Tomašić
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+**Mrežno mjesto**: https://stak.foi.hr/<br>
+**Kontakt**: stak@foi.hr<br>
+
+<ins><strong>Nakladnik</strong></ins><br>
+Sveučilište u Zagrebu<br>
+Fakultet organizacije i informatike<br>
+Pavlinska ulica 2<br>
+42000 Varaždin<br>
+<br>
+<ins><strong>Za nakladnika</strong></ins><br>
+prof. dr. sc. Marina Klačmer Čalopa
+<br>

--- a/src/routes/o-nama/+page.svelte
+++ b/src/routes/o-nama/+page.svelte
@@ -77,8 +77,8 @@
 	</div>
 </section>
 
-<section id="impresum" class="mx-10 mt-20 md:m-20 mb-0 md:mb-0">
-	<h2 class="wide-title text-7xl font-headline tracking-tighter mb-8 text-red-800 dark:text-red-200 xl:text-center">Impresum</h2>
+<section id="kronologija" class="mx-10 mt-20 md:m-20 mb-0 md:mb-0">
+	<h2 class="wide-title text-7xl font-headline tracking-tighter mb-8 text-red-800 dark:text-red-200 xl:text-center">Kronologija</h2>
 
 	<div class="xl:mx-auto my-20 lg:my-24 w-[90vw] max-w-xl">
 		<p class="text-justify max-sm:mr-10">
@@ -101,7 +101,7 @@
 	</div>
 </section>
 
-<section id="impresum" class="mx-10 mt-20 md:m-20 mb-0 md:mb-0">
+<section id="izdanja-casopisa" class="mx-10 mt-20 md:m-20 mb-0 md:mb-0">
 	<h2 class="wide-title text-7xl font-headline tracking-tighter mb-8 text-red-800 dark:text-red-200 xl:text-center">Izdanja časopisa</h2>
 
 	<div class="xl:mx-auto my-20 lg:my-24 max-w-xl">


### PR DESCRIPTION
The main focus of this PR was to fix the legalities concerning the Impressum page. This resulted in a new, separate web page `Impresum`. The previous Impresum, on the `O nama` page, was renamed to _Kronologija_.

Furthermore, this PR includes the following changes:
* renamed the magazine's page title to `Arhiva časopisa`
* the latest magazine on the `Arhiva časopisa`, i.e. its image, is now clickable
* moved student hub article to sponsored articles