### PR TITLE
Update headings of all pages to not go out of margin on sm screens

### DIFF
--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -10,7 +10,7 @@
     <title>Blog - St@k</title>
 </svelte:head>
 
-<h1 class="wide-title text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0 text-yellow-900 dark:text-yellow-200">
+<h1 class="wide-title text-7xl md:text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0 text-yellow-900 dark:text-yellow-200">
     Blog</h1>
 
 <nav class="ml-10 mr-10 md:ml-20 md:mr-20 mt-5 mb-0 md:mb-0">

--- a/src/routes/casopisi/+page.svelte
+++ b/src/routes/casopisi/+page.svelte
@@ -15,7 +15,7 @@
     <title>Arhiva časopisa - St@k</title>
 </svelte:head>
 
-<h1 class="wide-title text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0">Arhiva časopisa</h1>
+<h1 class="wide-title text-7xl md:text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0">Arhiva časopisa</h1>
 <h2 class="wide-title text-xl font-headline tracking-tighter mx-10 md:mx-20 mt-5 mb-0 md:mb-0">studentski list Fakulteta organizacije i informatike</h2>
 
 <div class="w-full flex max-xl:flex-col gap-40 p-10 md:p-20">

--- a/src/routes/impresum/+page.svelte
+++ b/src/routes/impresum/+page.svelte
@@ -9,7 +9,7 @@
     <title>Impresum - St@k</title>
 </svelte:head>
 
-<h1 class="wide-title text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0">Impresum</h1>
+<h1 class="wide-title text-7xl md:text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0">Impresum</h1>
 
 <section id="impresum" class="mt-20 md:m-20 mb-0 md:mb-0 p-10">
     <div class="article-content mx-auto prose dark:prose-invert prose-headings:max-w-[56ch] prose-p:max-w-[56ch] text-prose text-justify text-zinc-900 dark:text-slate-50">

--- a/src/routes/natjecanja/+page.svelte
+++ b/src/routes/natjecanja/+page.svelte
@@ -2,7 +2,7 @@
 	<title>Natjecanja - St@k</title>
 </svelte:head>
 
-<h1 class="wide-title text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0 text-violet-600 dark:text-violet-200">Natjecanja</h1>
+<h1 class="wide-title text-7xl md:text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0 text-violet-600 dark:text-violet-200">Natjecanja</h1>
 
 <section class="flex flex-col lg:flex-row mx-10 md:mx-20 gap-14 lg:gap-20 xl:mx-auto my-20 lg:my-32 w-[80vw] xl:w-max">
 	<picture>
@@ -15,7 +15,7 @@
 	</picture>	
 
 	<div class="flex flex-col gap-4 items-start justify-center max-w-md max-lg:ml-auto text-justify">
-		<h2 class="font-headline text-5xl font-semibold text-violet-500 dark:text-violet-200 tracking-tighter">Škljoc izvan okvira</h2>
+		<h2 class="font-headline text-4xl md:text-5xl font-semibold text-violet-500 dark:text-violet-200 tracking-tighter">Škljoc izvan okvira</h2>
 		<p>Škljoc izvan okvira fotografsko je natjecanje u kojemu se mogu okušati svi. Sve što je potrebno je posjedovati bilo koji oblik kamere i tonu kreativnosti.</p>
 
 		<p>
@@ -43,7 +43,7 @@
 	</picture>
 
 	<div class="flex flex-col gap-4 items-start justify-center max-w-md text-justify">
-		<h2 class="font-headline text-5xl font-semibold text-violet-500 dark:text-violet-200 tracking-tighter">2, 1, 0, kodiraj!</h2>
+		<h2 class="font-headline text-4xl md:text-5xl font-semibold text-violet-500 dark:text-violet-200 tracking-tighter">2, 1, 0, kodiraj!</h2>
 		<p>
 			Programersko natjecanje simboličnog naziva 2, 1, 0 kodiraj! jedan je od načina na koji bilo 
 			koji student FOI-ja može pokazati svoju kreativnost programerskog razmišljanja izvan okvira

--- a/src/routes/o-nama/+page.svelte
+++ b/src/routes/o-nama/+page.svelte
@@ -23,10 +23,10 @@
 	<title>O nama - St@k</title>
 </svelte:head>
 
-<h1 class="wide-title text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0 text-yellow-900 dark:text-yellow-200">O nama</h1>
+<h1 class="wide-title text-7xl md:text-9xl font-headline tracking-tighter m-10 md:m-20 mb-0 md:mb-0 text-yellow-900 dark:text-yellow-200">O nama</h1>
 
 <section id="o-nama" class="mx-10 mt-20 md:m-20 mb-0 md:mb-0">
-	<h2 class="wide-title text-7xl font-headline tracking-tighter mb-8 text-red-800 dark:text-red-200 xl:text-center">Tko? Što?</h2>
+	<h2 class="wide-title text-5xl md:text-7xl font-headline tracking-tighter mb-8 text-red-800 dark:text-red-200 xl:text-center">Tko? Što?</h2>
 
 	<div class="flex flex-col lg:flex-row gap-14 lg:gap-20 xl:mx-auto my-20 lg:my-24 w-[80vw] xl:w-max">
 		<div class="flex flex-col gap-4 items-start justify-center max-w-md text-justify">
@@ -78,7 +78,7 @@
 </section>
 
 <section id="kronologija" class="mx-10 mt-20 md:m-20 mb-0 md:mb-0">
-	<h2 class="wide-title text-7xl font-headline tracking-tighter mb-8 text-red-800 dark:text-red-200 xl:text-center">Kronologija</h2>
+	<h2 class="wide-title text-5xl md:text-7xl font-headline tracking-tighter mb-8 text-red-800 dark:text-red-200 xl:text-center">Kronologija</h2>
 
 	<div class="xl:mx-auto my-20 lg:my-24 w-[90vw] max-w-xl">
 		<p class="text-justify max-sm:mr-10">
@@ -102,7 +102,7 @@
 </section>
 
 <section id="izdanja-casopisa" class="mx-10 mt-20 md:m-20 mb-0 md:mb-0">
-	<h2 class="wide-title text-7xl font-headline tracking-tighter mb-8 text-red-800 dark:text-red-200 xl:text-center">Izdanja časopisa</h2>
+	<h2 class="wide-title text-5xl md:text-7xl font-headline tracking-tighter mb-8 text-red-800 dark:text-red-200 xl:text-center">Izdanja časopisa</h2>
 
 	<div class="xl:mx-auto my-20 lg:my-24 max-w-xl">
 		<Timeline position="left">
@@ -131,7 +131,7 @@
 </section>
 
 <section id="meet-the-crew" class="mx-10 mt-20 md:m-20 mb-0">
-	<h2 class="wide-title text-7xl font-headline tracking-tighter mb-8 text-red-800 dark:text-red-200 xl:text-center">Meet the crew</h2>
+	<h2 class="wide-title text-5xl md:text-7xl font-headline tracking-tighter mb-8 text-red-800 dark:text-red-200 xl:text-center">Meet the crew</h2>
 
 	<div class="flex flex-wrap gap-x-24 gap-y-16 justify-center pt-4 md:pt-8">
 		{#each members as { name, nameSlug, role, bio, imgRot: mobileImgRot, txtRot: mobileTxtRot, trOrigX: mobileTrOrigX, trOrigY: mobileTrOrigY, trX: mobileTrX, trY: mobileTrY, rot: mobileRot, bgCutout: mobileBgCutout, borderRadius: mobileBorderRadius }, i (i)}


### PR DESCRIPTION
Adjust each page heading to not go out of margins on smaller screens

**Changes:**
`text-7xl` instead of `text-9xl` on mobile
`text-5xl` instead of `text-7xl` on mobile
`text-4xl` instead of `text-5xl` on mobile